### PR TITLE
Use Lk instead of Aq for URLs - the latter is mostly for email addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ access tokens. pizauth is formed of two components: a persistent server which
 interacts with the user to request tokens, and refreshes them as necessary; and
 a command-line interface which can be used by programs such as
 [fdm](https://github.com/nicm/fdm) and [msmtp](https://marlam.de/msmtp/) to
-authenicate with OAuth2. Tokens are only ever stored in memory and are never
+authenticate with OAuth2. Tokens are only ever stored in memory and are never
 persisted to disk.
 
 

--- a/pizauth.1
+++ b/pizauth.1
@@ -68,4 +68,4 @@ period of time after this command returns.
 .An -nosplit
 .Nm
 was written by
-.An Laurence Tratt Aq https://tratt.net/laurie/
+.An Laurence Tratt Lk https://tratt.net/laurie/


### PR DESCRIPTION
Fix a small typo while there.