### PR TITLE
fix: implement daemon(3) for macOS (fixes #3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,6 +692,7 @@ dependencies = [
  "getopts",
  "getrandom",
  "json",
+ "libc",
  "log",
  "lrlex",
  "lrpar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,9 @@ urlencoding = "2"
 pledge = "0.4"
 unveil = "0.3"
 
+[target.'cfg(target_os="macos")'.dependencies]
+libc = "0.2"
+
 [profile.release]
 opt-level = 3
 debug = false

--- a/src/compat/daemon.rs
+++ b/src/compat/daemon.rs
@@ -1,0 +1,29 @@
+//! Provides daemon(3) on macOS.
+
+// We provide our own wrapper for daemon on macOS because nix does not export one for macOS.  This
+// is *probably* why nix does not support daemon(3) on macOS:
+//
+//  - nix will not compile on macOS, due to errors
+//  - ... nix compiles with #[deny(warnings)], which treats warnings as errors
+//  - libc emits a deprecation warning for daemon(3) on macOS [1]
+//  - ... because daemon(3) has been deprecated in macOS since Mac OS X 10.5
+//  - ... presumably because Apple wants you to use launchd(8) instead [2].
+//  - Therefore, this deprecation warning is treated as an error in nix
+//
+// [1]: https://github.com/rust-lang/libc/blob/96c85c1b913604fb5b1eb8822e344b7c08bcd6b9/src/unix/bsd/apple/mod.rs#L5064-L5067
+// [2]: https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html
+//
+// This module essentially reimplements nix's daemon wrapper on macOS, but allows deprecation
+// warnings.
+//
+// See: https://github.com/ltratt/pizauth/issues/3
+use libc::c_int;
+#[allow(deprecated)]
+use libc::daemon as libc_daemon;
+use nix::errno::Errno;
+
+pub fn daemon(nochdir: bool, noclose: bool) -> nix::Result<()> {
+    #[allow(deprecated)]
+    let res = unsafe { libc_daemon(nochdir as c_int, noclose as c_int) };
+    Errno::result(res).map(drop)
+}

--- a/src/compat/mod.rs
+++ b/src/compat/mod.rs
@@ -1,0 +1,11 @@
+//! Shims to provide compatibility with different systems.
+
+// nix does not support daemon(3) on macOS, so we have to provide our own implementation:
+#[cfg(target_os = "macos")]
+mod daemon;
+#[cfg(target_os = "macos")]
+pub use daemon::daemon;
+
+// Use nix's daemon(3) wrapper on other platforms:
+#[cfg(not(target_os = "macos"))]
+pub use nix::unistd::daemon;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::derive_partial_eq_without_eq)]
 
+mod compat;
 mod config;
 mod config_ast;
 mod server;
@@ -15,11 +16,11 @@ use std::{
 
 use getopts::Options;
 use log::error;
-use nix::unistd::daemon;
 #[cfg(target_os = "openbsd")]
 use pledge::pledge;
 use server::sock_path;
 
+use compat::daemon;
 use config::Config;
 use user_sender::show_token;
 


### PR DESCRIPTION
It builds on macOS now! I'll be honest, I don't know if it _works_ on macOS, but the tests pass and the application successfully daemonizes if run like this:

```
cargo run -- server -c ./pizauth.conf.example
```

Here's a screenshot from Activity Monitor (macOS 12.6, AArch64) after running this command:

![pizauth, shown as running in macOS's activity monitor](https://user-images.githubusercontent.com/2294397/196184358-ec10dd44-b66f-4326-bcce-bd555e4b83fb.png)

---

I'm not sure about creating `mod compat` in `src/main.rs`. I had originally created `src/compat.rs`, but I decided that all of the `![cfg(target_os = "macos")]` imports were better handled at the module level. Let me know what you think!

Fixes #3 