### PR TITLE
Add systemd unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ is opened in the user's default web browser.
 
 ### Running pizauth
 
-You need to start the pizauth server:
+You need to start the pizauth server (alternatively, start `pizauth.service`,
+see [systemd-unit](#systemd-unit) below):
 
 ```sh
 $ pizauth server
@@ -125,6 +126,30 @@ Note that:
      becoming invalid and pizauth realising that has happened and notifying you
      to request a new token.
 
+### Systemd unit
+
+Pizauth ships with a systemd unit and example configurations.
+To start `pizauth`, run
+
+```sh
+$ systemctl --user start pizauth.service
+```
+
+If you want `pizauth` to start on login, run
+
+```sh
+$ systemctl --user enable pizauth.service
+```
+
+Finally, in `systemd-dropins/` you'll find templates for saving pizauth dumps
+encrypted with `age` and `gpg`. To use them, run
+
+```sh
+$ systemctl --user edit pizauth.service
+```
+
+and paste whichever of these templates suits you in the file `systemctl` opens.
+(Modify the references to private/public keys to actually point to your keys!)
 
 ## Command-line interface
 

--- a/pizauth.service
+++ b/pizauth.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Pizauth OAuth2 token manager
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/pizauth server -vvvv -d
+ExecReload=/usr/bin/pizauth reload
+ExecStop=/usr/bin/pizauth shutdown
+
+[Install]
+WantedBy=default.target

--- a/systemd-dropins/age.conf
+++ b/systemd-dropins/age.conf
@@ -1,0 +1,6 @@
+[Service]
+Environment="PIZAUTH_STATE_FILE=%S/%N.dump"
+ExecStartPost=-sh -c 'age --decrypt --identity AGE_PRIV_KEY -o - "$PIZAUTH_STATE_FILE" | pizauth restore'
+ExecStop=
+ExecStop=-sh -c 'pizauth dump | age --encrypt --recipient AGE_PUB_KEY -o "$PIZAUTH_STATE_FILE"'
+ExecStop=/usr/bin/pizauth shutdown

--- a/systemd-dropins/gpg-dump.conf
+++ b/systemd-dropins/gpg-dump.conf
@@ -1,0 +1,11 @@
+[Unit]
+Requires=gpg-agent.socket
+
+[Service]
+PassEnvironment=GNUPGHOME
+Environment="PIZAUTH_KEY_ID="
+Environment="PIZAUTH_STATE_FILE=%S/%N.dump"
+ExecStartPost=-sh -c 'gpg --batch --decrypt "$PIZAUTH_STATE_FILE" | pizauth restore'
+ExecStop=
+ExecStop=-sh -c 'pizauth dump | gpg --batch --yes --encrypt --recipient $PIZAUTH_KEY_ID -o "$PIZAUTH_STATE_FILE"'
+ExecStop=/usr/bin/pizauth shutdown


### PR DESCRIPTION
Very belated, but I finally wrote the systemd unit.
(Certain idiosyncrasies of my system added unnecessary complications to the
development here, but at least I can finally give you this)

Also includes a configuration template for using `gpg` as the encryption
backend, which I'd understand if you want to remove. Included it because I had
some difficulty getting `gpg` to cooperate and thought the next person to use
`gpg` here might need the pointers.

Closes: #21
