### PR TITLE
Implement `pizauth revoke`.

### DIFF
--- a/pizauth.1
+++ b/pizauth.1
@@ -84,6 +84,15 @@ See
 .Sy dump
 for information about the dump format, timestamp warnings, and encryption
 suggestions.
+.It Sy revoke Ar account
+Removes any token, and cancels any ongoing authentication, for
+.Em account .
+Note that OAuth2 provides no standard way of remotely revoking a token:
+.Sy revoke
+thus only affects the local
+.Nm
+instance.
+Exits with 0 upon success.
 .It Sy server Oo Fl c Ar config-file Oc Oo Fl dv Oc
 Start the server.
 If not specified with

--- a/pizauth.conf.5
+++ b/pizauth.conf.5
@@ -84,7 +84,10 @@ if a previously valid access token is invalidated;
 .Em token_new
 if a new access token is obtained;
 .Em token_refreshed
-if an access token is refreshed.
+if an access token is refreshed;
+.Em token_revoked
+if the user has requested that any token, or ongoing authentication for,
+an account should be removed or cancelled.
 Token events are queued and processed one-by-one in the order they were
 received: at most one instance of
 .Sy token_event_cmd

--- a/share/bash/completion.bash
+++ b/share/bash/completion.bash
@@ -40,6 +40,14 @@ _pizauth()
                     mapfile -t COMPREPLY < \
                         <(compgen -W "${accounts[*]}" -- "$cur")
                     ;;
+                revoke)
+                    local accounts
+                    mapfile -t accounts < <(_accounts)
+                    mapfile -t COMPREPLY < \
+                        <(compgen -W "${accounts[*]}" -- "$cur")
+                    ;;
+                *) COMPREPLY=()
+                ;;
             esac
             ;;
         3)

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ fn fatal(msg: &str) -> ! {
 fn usage() -> ! {
     let pn = progname();
     eprintln!(
-        "Usage:\n  {pn:} dump\n  {pn:} info [-j]\n  {pn:} refresh [-u] <account>\n  {pn:} restore\n  {pn:} reload\n  {pn:} server [-c <config-path>] [-dv]\n  {pn:} show [-u] <account>\n  {pn:} shutdown\n  {pn:} status"
+        "Usage:\n  {pn:} dump\n  {pn:} info [-j]\n  {pn:} refresh [-u] <account>\n  {pn:} restore\n  {pn:} reload\n  {pn:} revoke <account>\n  {pn:} server [-c <config-path>] [-dv]\n  {pn:} show [-u] <account>\n  {pn:} shutdown\n  {pn:} status"
     );
     process::exit(1)
 }
@@ -219,6 +219,21 @@ fn main() {
                 .init()
                 .unwrap();
             if let Err(e) = user_sender::restore(&cache_path) {
+                error!("{e:}");
+                process::exit(1);
+            }
+        }
+        "revoke" => {
+            let matches = opts.parse(&args[2..]).unwrap_or_else(|_| usage());
+            if matches.opt_present("h") || matches.free.len() != 1 {
+                usage();
+            }
+            stderrlog::new()
+                .module(module_path!())
+                .verbosity(matches.opt_count("v"))
+                .init()
+                .unwrap();
+            if let Err(e) = user_sender::revoke(&cache_path, &matches.free[0]) {
                 error!("{e:}");
                 process::exit(1);
             }

--- a/src/server/eventer.rs
+++ b/src/server/eventer.rs
@@ -21,6 +21,7 @@ pub enum TokenEvent {
     Invalidated,
     New,
     Refresh,
+    Revoked,
 }
 
 impl Display for TokenEvent {
@@ -29,6 +30,7 @@ impl Display for TokenEvent {
             TokenEvent::Invalidated => write!(f, "token_invalidated"),
             TokenEvent::New => write!(f, "token_new"),
             TokenEvent::Refresh => write!(f, "token_refreshed"),
+            TokenEvent::Revoked => write!(f, "token_revoked"),
         }
     }
 }


### PR DESCRIPTION
Currently this is local-only as OAuth2 provides no standard way of revoking remote tokens (though some providers do provide ad-hoc extensions to do so).

Fixes https://github.com/ltratt/pizauth/issues/29. @hseg Please see if this works for you (I have lightly, but not yet extensively, tested it).