### PR TITLE
Add completion for revoke subcommand itself

### DIFF
--- a/share/bash/completion.bash
+++ b/share/bash/completion.bash
@@ -19,7 +19,10 @@ _accounts(){
 _pizauth()
 {
     local cur prev sub
-    local cmds=(dump info refresh restore reload server show shutdown status)
+    local cmds=()
+    cmds+=(dump restore reload shutdown status)
+    cmds+=(info server)
+    cmds+=(refresh revoke show)
 
     cur=${COMP_WORDS[COMP_CWORD]}
     prev=${COMP_WORDS[COMP_CWORD - 1]}


### PR DESCRIPTION
As it stands, bash completes when the subcommand is present (so `pizauth revoke
<TAB>`), but not the subcommand itself (ie `pizauth rev<TAB>`).
To fix this, add `revoke` to the list `cmds` of known subcommands.

To avoid this in the future, perhaps use an argparsing library that provides
completion generation, eg <https://github.com/clap-rs/clap>? Cf
<https://github.com/rosetta-rs/argparse-rosetta-rs> for more alternatives.

`bash-completion` offers docopt-style completion generators by the names
`_comp_compgen_{help,usage}`, but I couldn't get them to do anything useful.

Closes: [addendum to #30](https://github.com/ltratt/pizauth/pull/30#issuecomment-1883612245)
