### PR TITLE
Add the ability to print out server info.

### DIFF
--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -45,10 +45,12 @@ pub struct AuthenticatorState {
     /// The "global lock" protecting the config and current [TokenState]s. Can only be accessed via
     /// [AuthenticatorState::ct_lock].
     locked_state: Mutex<LockedState>,
-    /// port of the HTTP server required by OAuth.
+    /// Port of the HTTP server required by OAuth.
     pub http_port: Option<u16>,
-    /// port of the HTTPS server required by OAuth.
+    /// Port of the HTTPS server required by OAuth.
     pub https_port: Option<u16>,
+    /// If an HTTPS server is running, its raw public key formatted in hex with each byte separated by `:`.
+    pub https_pub_key: Option<String>,
     pub eventer: Arc<Eventer>,
     pub notifier: Arc<Notifier>,
     pub refresher: Arc<Refresher>,
@@ -60,6 +62,7 @@ impl AuthenticatorState {
         conf: Config,
         http_port: Option<u16>,
         https_port: Option<u16>,
+        https_pub_key: Option<String>,
         eventer: Arc<Eventer>,
         notifier: Arc<Notifier>,
         refresher: Arc<Refresher>,
@@ -69,6 +72,7 @@ impl AuthenticatorState {
             locked_state: Mutex::new(LockedState::new(conf)),
             http_port,
             https_port,
+            https_pub_key,
             eventer,
             notifier,
             refresher,
@@ -594,6 +598,7 @@ mod test {
             conf,
             Some(0),
             Some(0),
+            Some("".to_string()),
             eventer,
             notifier,
             Refresher::new(),
@@ -727,6 +732,7 @@ mod test {
             conf,
             Some(0),
             Some(0),
+            Some("".to_string()),
             eventer,
             notifier,
             Refresher::new(),
@@ -808,6 +814,7 @@ mod test {
             conf,
             Some(0),
             Some(0),
+            Some("".to_string()),
             eventer,
             notifier,
             Refresher::new(),


### PR DESCRIPTION
In particular, this allows the HTTPS public key to be printed so that one can verify that the browser is actually connecting to the expected server. For example:

```
$ cargo run info
pizauth version 1.0.5:
  cache directory: /tmp/runtime-ltratt/pizauth
  config file: /home/ltratt/.config/pizauth.conf
server running:
  HTTP port: 7470
  HTTPS port: 24004
  HTTPS public key: 04:70:57:B0:9A:B4:1C:F9:CB:2E:33:CB:71:D9:B1:7C:5C:6E:84:8F:25:66:F4:C8:1E:3F:41:F8:34:8D:2A:6A:3F:26:D9:A6:57:27:D0:B0:93:09:5B:50:70:D9:DD:1A:A0:DE:33:04:E1:A8:FB:C6:30:D2:92:B1:26:11:E5:75:B9
```

Note this requires a bump to the JSON info version.

@trembel This solves the major remaining weakness with the HTTPS support as I see it. Of course, one could always do more e.g. allowing users to specify their own certificates. But this feels like it's enough for someone to have confidence in the HTTPS support in pizauth. Does it work as expected for you?