### PR TITLE
Move from bincode to wincode.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,6 +749,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,6 +1080,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,7 +1102,6 @@ name = "pizauth"
 version = "1.0.11"
 dependencies = [
  "base64",
- "bincode",
  "boot-time",
  "cfgrammar",
  "chacha20poly1305",
@@ -1082,6 +1128,7 @@ dependencies = [
  "url",
  "wait-timeout",
  "whoami",
+ "wincode",
 ]
 
 [[package]]
@@ -1432,6 +1479,12 @@ dependencies = [
  "termcolor",
  "thread_local",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1890,6 +1943,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wincode"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c754f1fc41250f2f742a27ba0fcc9f73df1dec23f6878490770855d43c322d"
+dependencies = [
+ "pastey",
+ "proc-macro2",
+ "quote",
+ "thiserror",
+ "wincode-derive",
+]
+
+[[package]]
+name = "wincode-derive"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e070787599c7c067b89598cd3eda440cca1b69eda9e0ff7c725fc8679ce9eb4"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ rerun_except = "1"
 
 [dependencies]
 base64 = "0.22"
-bincode = { version="2", features=["serde"] }
 boot-time = "0.1.2"
 cfgrammar = "0.14"
 chacha20poly1305 = "0.10"
@@ -41,6 +40,7 @@ wait-timeout = "0.2"
 whoami = "2.1.2"
 rustls = { version = "0.23.12", features = ["ring", "std"], default-features = false }
 rcgen = { version = "0.14.5", features = ["crypto", "ring"], default-features = false }
+wincode = { version = "0.5.3", features = ["derive"] }
 
 [target.'cfg(target_os="openbsd")'.dependencies]
 pledge = "0.4"

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,7 @@ use lrlex::{lrlex_mod, DefaultLexerTypes, LRNonStreamingLexer};
 use lrpar::{lrpar_mod, NonStreamingLexer, Span};
 use serde::{Deserialize, Serialize};
 use url::Url;
+use wincode::{SchemaRead, SchemaWrite};
 
 use crate::config_ast;
 
@@ -597,7 +598,7 @@ impl Account {
     }
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, SchemaRead, SchemaWrite)]
 pub struct AccountDump {
     auth_uri: String,
     auth_uri_fields: Vec<(String, String)>,

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -27,6 +27,7 @@ use chacha20poly1305::{
 use rand::{rng, RngExt};
 use serde::{Deserialize, Serialize};
 use url::Url;
+use wincode::{deserialize, serialize, SchemaRead, SchemaWrite};
 
 use super::{eventer::Eventer, notifier::Notifier, refresher::Refresher};
 use crate::config::{Account, AccountDump, Config};
@@ -234,17 +235,14 @@ impl LockedState {
             );
         }
 
-        Ok(bincode::serde::encode_to_vec(
-            &Dump {
-                version: DUMP_VERSION,
-                accounts: acts,
-            },
-            bincode::config::legacy(),
-        )?)
+        Ok(serialize(&Dump {
+            version: DUMP_VERSION,
+            accounts: acts,
+        })?)
     }
 
     fn restore(&mut self, dump: Vec<u8>) -> Result<(), Box<dyn Error>> {
-        let d: Dump = bincode::serde::decode_from_slice(&dump, bincode::config::legacy())?.0;
+        let d: Dump = deserialize(&dump)?;
         if d.version != DUMP_VERSION {
             return Err("Unknown dump version".into());
         }
@@ -295,7 +293,7 @@ impl LockedState {
     }
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, SchemaRead, SchemaWrite)]
 struct Dump {
     version: u64,
     accounts: HashMap<String, (AccountDump, TokenStateDump)>,
@@ -473,7 +471,7 @@ pub enum TokenState {
     },
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, SchemaRead, SchemaWrite)]
 /// The format of a dumped [TokenState]. Note that [std::time::Instant] instances are translated to
 /// [std::time::SystemTime] instances: there is no guarantee that we can precisely represent the
 /// latter as the former, so when conversions fail we default to setting values to
@@ -919,13 +917,10 @@ mod test {
             }
         }
         // Create a dump file with an unsupported version number.
-        let plaintext = bincode::serde::encode_to_vec(
-            &Dump {
-                version: DUMP_VERSION + 1,
-                accounts,
-            },
-            bincode::config::legacy(),
-        )
+        let plaintext = serialize(&Dump {
+            version: DUMP_VERSION + 1,
+            accounts,
+        })
         .unwrap();
         let key = Key::from_slice(CHACHA20_KEY);
         let cipher = ChaCha20Poly1305::new(key);


### PR DESCRIPTION
bincode is no longer supported and, for our purposes, wincode is binary compatible, so bincode era `dump`s still work with wincode era `restore`s.