### PR TITLE
Straightforward Clippy linting suggestions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,6 @@ let_underscore = "warn"
 ## TODO, disabled since they currently fail
 elided_lifetimes_in_paths = { level = "allow", priority = 1 }
 tail_expr_drop_order = { level = "allow", priority = 1 }
-if_let_rescope = { level = "allow", priority = 1 }
 
 [lints.clippy]
 pedantic = "warn"
@@ -97,7 +96,6 @@ unused_self = { level = "allow", priority = 1 }
 nursery = "warn"
 ## TODO, disabled since they currently fail
 redundant_clone = { level = "allow", priority = 1 }
-significant_drop_in_scrutinee = { level = "allow", priority = 1 }
 significant_drop_tightening = { level = "allow", priority = 1 }
 needless_collect = { level = "allow", priority = 1 }
 missing_const_for_fn = { level = "allow", priority = 1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,59 @@ codegen-units = 1
 panic = 'abort'
 incremental = false
 overflow-checks = true
+
+[lints.rust]
+future_incompatible = "warn"
+keyword_idents = "warn"
+nonstandard_style = "warn"
+rust_2018_compatibility = "deny"
+rust_2018_idioms = "deny"
+rust_2021_compatibility = "deny"
+rust_2024_compatibility = "deny"
+let_underscore = "warn"
+
+## TODO, disabled since they currently fail
+elided_lifetimes_in_paths = { level = "allow", priority = 1 }
+rust_2024_incompatible_pat = { level = "allow", priority = 1 }
+let_underscore_drop = { level = "allow", priority = 1 }
+tail_expr_drop_order = { level = "allow", priority = 1 }
+if_let_rescope = { level = "allow", priority = 1 }
+
+[lints.clippy]
+pedantic = "warn"
+## TODO, disabled since they currently fail
+similar_names = { level = "allow", priority = 1 }
+redundant_else = { level = "allow", priority = 1 }
+too_many_lines = { level = "allow", priority = 1 }
+manual_let_else = { level = "allow", priority = 1 } # pervasive if we want to be consistent
+single_match_else = { level = "allow", priority = 1 }
+implicit_clone = { level = "allow", priority = 1 }
+unnecessary_wraps = { level = "allow", priority = 1 }
+duration_suboptimal_units = { level = "allow", priority = 1 }
+doc_markdown = { level = "allow", priority = 1 }
+unnecessary_debug_formatting = { level = "allow", priority = 1 }
+use_self = { level = "allow", priority = 1 }
+uninlined_format_args = { level = "allow", priority = 1 }
+needless_pass_by_value = { level = "allow", priority = 1 }
+ignored_unit_patterns = { level = "allow", priority = 1 }
+redundant_closure_for_method_calls = { level = "allow", priority = 1 }
+unused_self = { level = "allow", priority = 1 }
+
+nursery = "warn"
+## TODO, disabled since they currently fail
+redundant_clone = { level = "allow", priority = 1 }
+significant_drop_in_scrutinee = { level = "allow", priority = 1 }
+significant_drop_tightening = { level = "allow", priority = 1 }
+needless_collect = { level = "allow", priority = 1 }
+explicit_into_iter_loop = { level = "allow", priority = 1 }
+explicit_iter_loop = { level = "allow", priority = 1 }
+missing_const_for_fn = { level = "allow", priority = 1 }
+inconsistent_struct_constructor = { level = "allow", priority = 1 }
+string_lit_as_bytes = { level = "allow", priority = 1 }
+path_buf_push_overwrite = { level = "allow", priority = 1 }
+unnested_or_patterns = { level = "allow", priority = 1 }
+map_unwrap_or = { level = "allow", priority = 1 }
+semicolon_if_nothing_returned = { level = "allow", priority = 1 }
+equatable_if_let = { level = "allow", priority = 1 }
+option_if_let_else = { level = "allow", priority = 1 }
+match_same_arms = { level = "allow", priority = 1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,6 @@ implicit_clone = { level = "allow", priority = 1 }
 unnecessary_wraps = { level = "allow", priority = 1 }
 duration_suboptimal_units = { level = "allow", priority = 1 }
 unnecessary_debug_formatting = { level = "allow", priority = 1 }
-uninlined_format_args = { level = "allow", priority = 1 }
 needless_pass_by_value = { level = "allow", priority = 1 }
 ignored_unit_patterns = { level = "allow", priority = 1 }
 redundant_closure_for_method_calls = { level = "allow", priority = 1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,5 +107,4 @@ explicit_iter_loop = { level = "allow", priority = 1 }
 missing_const_for_fn = { level = "allow", priority = 1 }
 path_buf_push_overwrite = { level = "allow", priority = 1 }
 map_unwrap_or = { level = "allow", priority = 1 }
-equatable_if_let = { level = "allow", priority = 1 }
 option_if_let_else = { level = "allow", priority = 1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,6 @@ string_lit_as_bytes = { level = "allow", priority = 1 }
 path_buf_push_overwrite = { level = "allow", priority = 1 }
 unnested_or_patterns = { level = "allow", priority = 1 }
 map_unwrap_or = { level = "allow", priority = 1 }
-semicolon_if_nothing_returned = { level = "allow", priority = 1 }
 equatable_if_let = { level = "allow", priority = 1 }
 option_if_let_else = { level = "allow", priority = 1 }
 match_same_arms = { level = "allow", priority = 1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,29 +74,39 @@ rust_2024_compatibility = "deny"
 let_underscore = "warn"
 
 ## TODO, disabled since they currently fail
+### Would change style
 elided_lifetimes_in_paths = { level = "allow", priority = 1 }
+### Needs analysis + oversight for correctness
 tail_expr_drop_order = { level = "allow", priority = 1 }
 
 [lints.clippy]
 pedantic = "warn"
 ## TODO, disabled since they currently fail
+### Straightforward fix, for next PR
+ignored_unit_patterns = { level = "allow", priority = 1 }
+implicit_clone = { level = "allow", priority = 1 }
+unused_self = { level = "allow", priority = 1 }
+### Lint guidance seems wrong, needs decision
 similar_names = { level = "allow", priority = 1 }
-redundant_else = { level = "allow", priority = 1 }
+unnecessary_debug_formatting = { level = "allow", priority = 1 }
+redundant_closure_for_method_calls = { level = "allow", priority = 1 }
+#### Straightforward, depending on design decisions
+unnecessary_wraps = { level = "allow", priority = 1 }
+### Heavy changes, each of these needs its own PR
 too_many_lines = { level = "allow", priority = 1 }
 manual_let_else = { level = "allow", priority = 1 } # pervasive if we want to be consistent
 single_match_else = { level = "allow", priority = 1 }
-implicit_clone = { level = "allow", priority = 1 }
-unnecessary_wraps = { level = "allow", priority = 1 }
-unnecessary_debug_formatting = { level = "allow", priority = 1 }
+redundant_else = { level = "allow", priority = 1 }
+### Needs analysis + oversight for correctness
 needless_pass_by_value = { level = "allow", priority = 1 }
-ignored_unit_patterns = { level = "allow", priority = 1 }
-redundant_closure_for_method_calls = { level = "allow", priority = 1 }
-unused_self = { level = "allow", priority = 1 }
 
 nursery = "warn"
 ## TODO, disabled since they currently fail
+### Straightforward fix, for next PR
 redundant_clone = { level = "allow", priority = 1 }
-significant_drop_tightening = { level = "allow", priority = 1 }
 needless_collect = { level = "allow", priority = 1 }
-missing_const_for_fn = { level = "allow", priority = 1 }
+### Would change style, need buy-in + style guide
 option_if_let_else = { level = "allow", priority = 1 }
+### Needs analysis + oversight for correctness
+missing_const_for_fn = { level = "allow", priority = 1 }
+significant_drop_tightening = { level = "allow", priority = 1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,6 @@ single_match_else = { level = "allow", priority = 1 }
 implicit_clone = { level = "allow", priority = 1 }
 unnecessary_wraps = { level = "allow", priority = 1 }
 duration_suboptimal_units = { level = "allow", priority = 1 }
-doc_markdown = { level = "allow", priority = 1 }
 unnecessary_debug_formatting = { level = "allow", priority = 1 }
 use_self = { level = "allow", priority = 1 }
 uninlined_format_args = { level = "allow", priority = 1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,6 @@ needless_collect = { level = "allow", priority = 1 }
 explicit_into_iter_loop = { level = "allow", priority = 1 }
 explicit_iter_loop = { level = "allow", priority = 1 }
 missing_const_for_fn = { level = "allow", priority = 1 }
-string_lit_as_bytes = { level = "allow", priority = 1 }
 path_buf_push_overwrite = { level = "allow", priority = 1 }
 map_unwrap_or = { level = "allow", priority = 1 }
 equatable_if_let = { level = "allow", priority = 1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,6 @@ implicit_clone = { level = "allow", priority = 1 }
 unnecessary_wraps = { level = "allow", priority = 1 }
 duration_suboptimal_units = { level = "allow", priority = 1 }
 unnecessary_debug_formatting = { level = "allow", priority = 1 }
-use_self = { level = "allow", priority = 1 }
 uninlined_format_args = { level = "allow", priority = 1 }
 needless_pass_by_value = { level = "allow", priority = 1 }
 ignored_unit_patterns = { level = "allow", priority = 1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,8 +102,6 @@ redundant_clone = { level = "allow", priority = 1 }
 significant_drop_in_scrutinee = { level = "allow", priority = 1 }
 significant_drop_tightening = { level = "allow", priority = 1 }
 needless_collect = { level = "allow", priority = 1 }
-explicit_into_iter_loop = { level = "allow", priority = 1 }
-explicit_iter_loop = { level = "allow", priority = 1 }
 missing_const_for_fn = { level = "allow", priority = 1 }
 path_buf_push_overwrite = { level = "allow", priority = 1 }
 map_unwrap_or = { level = "allow", priority = 1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,5 @@ redundant_clone = { level = "allow", priority = 1 }
 significant_drop_tightening = { level = "allow", priority = 1 }
 needless_collect = { level = "allow", priority = 1 }
 missing_const_for_fn = { level = "allow", priority = 1 }
-path_buf_push_overwrite = { level = "allow", priority = 1 }
 map_unwrap_or = { level = "allow", priority = 1 }
 option_if_let_else = { level = "allow", priority = 1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,8 +110,6 @@ missing_const_for_fn = { level = "allow", priority = 1 }
 inconsistent_struct_constructor = { level = "allow", priority = 1 }
 string_lit_as_bytes = { level = "allow", priority = 1 }
 path_buf_push_overwrite = { level = "allow", priority = 1 }
-unnested_or_patterns = { level = "allow", priority = 1 }
 map_unwrap_or = { level = "allow", priority = 1 }
 equatable_if_let = { level = "allow", priority = 1 }
 option_if_let_else = { level = "allow", priority = 1 }
-match_same_arms = { level = "allow", priority = 1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,5 +99,4 @@ redundant_clone = { level = "allow", priority = 1 }
 significant_drop_tightening = { level = "allow", priority = 1 }
 needless_collect = { level = "allow", priority = 1 }
 missing_const_for_fn = { level = "allow", priority = 1 }
-map_unwrap_or = { level = "allow", priority = 1 }
 option_if_let_else = { level = "allow", priority = 1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,6 @@ needless_collect = { level = "allow", priority = 1 }
 explicit_into_iter_loop = { level = "allow", priority = 1 }
 explicit_iter_loop = { level = "allow", priority = 1 }
 missing_const_for_fn = { level = "allow", priority = 1 }
-inconsistent_struct_constructor = { level = "allow", priority = 1 }
 string_lit_as_bytes = { level = "allow", priority = 1 }
 path_buf_push_overwrite = { level = "allow", priority = 1 }
 map_unwrap_or = { level = "allow", priority = 1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,6 @@ let_underscore = "warn"
 
 ## TODO, disabled since they currently fail
 elided_lifetimes_in_paths = { level = "allow", priority = 1 }
-rust_2024_incompatible_pat = { level = "allow", priority = 1 }
 let_underscore_drop = { level = "allow", priority = 1 }
 tail_expr_drop_order = { level = "allow", priority = 1 }
 if_let_rescope = { level = "allow", priority = 1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,6 @@ let_underscore = "warn"
 
 ## TODO, disabled since they currently fail
 elided_lifetimes_in_paths = { level = "allow", priority = 1 }
-let_underscore_drop = { level = "allow", priority = 1 }
 tail_expr_drop_order = { level = "allow", priority = 1 }
 if_let_rescope = { level = "allow", priority = 1 }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,6 @@ manual_let_else = { level = "allow", priority = 1 } # pervasive if we want to be
 single_match_else = { level = "allow", priority = 1 }
 implicit_clone = { level = "allow", priority = 1 }
 unnecessary_wraps = { level = "allow", priority = 1 }
-duration_suboptimal_units = { level = "allow", priority = 1 }
 unnecessary_debug_formatting = { level = "allow", priority = 1 }
 needless_pass_by_value = { level = "allow", priority = 1 }
 ignored_unit_patterns = { level = "allow", priority = 1 }

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+doc-valid-idents = [ "OAuth", "OAuth2", "ChaCha20", ".." ]

--- a/src/config.rs
+++ b/src/config.rs
@@ -110,7 +110,7 @@ impl Config {
                                 "auth_notify_cmd",
                                 span,
                                 auth_notify_cmd,
-                            )?)
+                            )?);
                         }
                         config_ast::TopLevel::AuthNotifyInterval(span) => {
                             auth_notify_interval =
@@ -119,7 +119,7 @@ impl Config {
                                     "auth_notify_interval",
                                     span,
                                     auth_notify_interval,
-                                )?)?)
+                                )?)?);
                         }
                         config_ast::TopLevel::ErrorNotifyCmd(span) => {
                             error_notify_cmd = Some(check_not_assigned_str(
@@ -127,7 +127,7 @@ impl Config {
                                 "error_notify_cmd",
                                 span,
                                 error_notify_cmd,
-                            )?)
+                            )?);
                         }
                         config_ast::TopLevel::HttpListen(span) => {
                             http_listen = Some(Some(check_not_assigned_str(
@@ -135,11 +135,11 @@ impl Config {
                                 "http_listen",
                                 span,
                                 http_listen,
-                            )?))
+                            )?));
                         }
                         config_ast::TopLevel::HttpListenNone(span) => {
                             check_not_assigned(&lexer, "http_listen", span, http_listen)?;
-                            http_listen = Some(None)
+                            http_listen = Some(None);
                         }
                         config_ast::TopLevel::HttpsListen(span) => {
                             https_listen = Some(Some(check_not_assigned_str(
@@ -147,11 +147,11 @@ impl Config {
                                 "https_listen",
                                 span,
                                 https_listen,
-                            )?))
+                            )?));
                         }
                         config_ast::TopLevel::HttpsListenNone(span) => {
                             check_not_assigned(&lexer, "https_listen", span, https_listen)?;
-                            https_listen = Some(None)
+                            https_listen = Some(None);
                         }
                         config_ast::TopLevel::TransientErrorIfCmd(span) => {
                             transient_error_if_cmd = Some(check_not_assigned_str(
@@ -159,15 +159,16 @@ impl Config {
                                 "transient_error_if_cmd",
                                 span,
                                 transient_error_if_cmd,
-                            )?)
+                            )?);
                         }
                         config_ast::TopLevel::RefreshAtLeast(span) => {
-                            refresh_at_least = Some(time_str_to_duration(check_not_assigned_time(
-                                &lexer,
-                                "refresh_at_least",
-                                span,
-                                refresh_at_least,
-                            )?)?)
+                            refresh_at_least =
+                                Some(time_str_to_duration(check_not_assigned_time(
+                                    &lexer,
+                                    "refresh_at_least",
+                                    span,
+                                    refresh_at_least,
+                                )?)?);
                         }
                         config_ast::TopLevel::RefreshBeforeExpiry(span) => {
                             refresh_before_expiry =
@@ -176,7 +177,7 @@ impl Config {
                                     "refresh_before_expiry",
                                     span,
                                     refresh_before_expiry,
-                                )?)?)
+                                )?)?);
                         }
                         config_ast::TopLevel::RefreshRetry(span) => {
                             refresh_retry = Some(time_str_to_duration(check_not_assigned_time(
@@ -184,7 +185,7 @@ impl Config {
                                 "refresh_retry",
                                 span,
                                 refresh_retry,
-                            )?)?)
+                            )?)?);
                         }
                         config_ast::TopLevel::StartupCmd(span) => {
                             startup_cmd = Some(check_not_assigned_str(
@@ -192,7 +193,7 @@ impl Config {
                                 "startup_cmd",
                                 span,
                                 startup_cmd,
-                            )?)
+                            )?);
                         }
                         config_ast::TopLevel::TokenEventCmd(span) => {
                             token_event_cmd = Some(check_not_assigned_str(
@@ -200,7 +201,7 @@ impl Config {
                                 "token_event_cmd",
                                 span,
                                 token_event_cmd,
-                            )?)
+                            )?);
                         }
                     }
                 }
@@ -396,7 +397,7 @@ impl Account {
         for f in fields {
             match f {
                 config_ast::AccountField::AuthUri(span) => {
-                    auth_uri = Some(check_not_assigned_uri(lexer, "auth_uri", span, auth_uri)?)
+                    auth_uri = Some(check_not_assigned_uri(lexer, "auth_uri", span, auth_uri)?);
                 }
                 config_ast::AccountField::AuthUriFields(span, spans) => {
                     if auth_uri_fields.is_some() {
@@ -420,7 +421,7 @@ impl Account {
                     );
                 }
                 config_ast::AccountField::ClientId(span) => {
-                    client_id = Some(check_not_assigned_str(lexer, "client_id", span, client_id)?)
+                    client_id = Some(check_not_assigned_str(lexer, "client_id", span, client_id)?);
                 }
                 config_ast::AccountField::ClientSecret(span) => {
                     client_secret = Some(check_not_assigned_str(
@@ -428,7 +429,7 @@ impl Account {
                         "client_secret",
                         span,
                         client_secret,
-                    )?)
+                    )?);
                 }
                 config_ast::AccountField::LoginHint(span) => {
                     login_hint = Some(check_not_assigned_str(
@@ -436,11 +437,11 @@ impl Account {
                         "login_hint",
                         span,
                         login_hint,
-                    )?)
+                    )?);
                 }
                 config_ast::AccountField::RedirectUri(span) => {
                     let uri = check_not_assigned_uri(lexer, "redirect_uri", span, redirect_uri)?;
-                    redirect_uri = Some(uri)
+                    redirect_uri = Some(uri);
                 }
                 config_ast::AccountField::RefreshAtLeast(span) => {
                     refresh_at_least = Some(time_str_to_duration(check_not_assigned_time(
@@ -448,7 +449,7 @@ impl Account {
                         "refresh_at_least",
                         span,
                         refresh_at_least,
-                    )?)?)
+                    )?)?);
                 }
                 config_ast::AccountField::RefreshBeforeExpiry(span) => {
                     refresh_before_expiry = Some(time_str_to_duration(check_not_assigned_time(
@@ -456,7 +457,7 @@ impl Account {
                         "refresh_before_expiry",
                         span,
                         refresh_before_expiry,
-                    )?)?)
+                    )?)?);
                 }
                 config_ast::AccountField::RefreshRetry(span) => {
                     refresh_retry = Some(time_str_to_duration(check_not_assigned_time(
@@ -464,7 +465,7 @@ impl Account {
                         "refresh_retry",
                         span,
                         refresh_retry,
-                    )?)?)
+                    )?)?);
                 }
                 config_ast::AccountField::Scopes(span, spans) => {
                     if scopes.is_some() {
@@ -483,7 +484,7 @@ impl Account {
                     );
                 }
                 config_ast::AccountField::TokenUri(span) => {
-                    token_uri = Some(check_not_assigned_uri(lexer, "token_uri", span, token_uri)?)
+                    token_uri = Some(check_not_assigned_uri(lexer, "token_uri", span, token_uri)?);
                 }
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,7 @@ type StorageT = u8;
 const REFRESH_BEFORE_EXPIRY_DEFAULT: Duration = Duration::from_secs(90);
 /// How many seconds before we forcibly try refreshing an access token, even if it's not yet
 /// expired?
-const REFRESH_AT_LEAST_DEFAULT: Duration = Duration::from_secs(90 * 60);
+const REFRESH_AT_LEAST_DEFAULT: Duration = Duration::from_mins(90);
 /// How many seconds after a refresh failed in a non-permanent way before we retry refreshing?
 const REFRESH_RETRY_DEFAULT: Duration = Duration::from_secs(40);
 /// How many seconds do we raise a notification if it only contains authorisations that have been

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,7 +54,7 @@ impl Config {
             Ok(s) => s,
             Err(e) => return Err(format!("Can't read {:?}: {}", conf_path, e)),
         };
-        Config::from_str(&input)
+        Self::from_str(&input)
     }
 
     pub fn from_str(input: &str) -> Result<Self, String> {
@@ -235,7 +235,7 @@ impl Config {
             }
         }
 
-        Ok(Config {
+        Ok(Self {
             accounts,
             auth_notify_cmd,
             auth_notify_interval: auth_notify_interval
@@ -501,7 +501,7 @@ impl Account {
             }
         }
 
-        Ok(Account {
+        Ok(Self {
             name,
             auth_uri,
             auth_uri_fields: auth_uri_fields.unwrap_or_default(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,9 +25,9 @@ const REFRESH_RETRY_DEFAULT: Duration = Duration::from_secs(40);
 /// How many seconds do we raise a notification if it only contains authorisations that have been
 /// shown before?
 const AUTH_NOTIFY_INTERVAL_DEFAULT: u64 = 15 * 60;
-/// What is the default bind() address for the HTTP server?
+/// What is the default `bind()` address for the HTTP server?
 const HTTP_LISTEN_DEFAULT: &str = "127.0.0.1:0";
-/// What is the default bind() address for the HTTPS server?
+/// What is the default `bind()` address for the HTTPS server?
 const HTTPS_LISTEN_DEFAULT: &str = "127.0.0.1:0";
 
 #[derive(Debug)]
@@ -548,10 +548,10 @@ impl Account {
         }
     }
 
-    /// Can this account's tokenstate safely be restored from an [AccountDump] `act_dump`? Roughly
+    /// Can this account's tokenstate safely be restored from `act_dump`? Roughly
     /// speaking, if `act_dump` was converted into an `Account`, would that new `Account` compare
-    /// equal with `secure_eq` to `self`? If `true`, then it is safe to restore the (`self`)
-    /// `Account`'s tokenstate from a dump.
+    /// equal with `secure_eq` to `self`? If `true`, then it is safe to restore `self`'s
+    /// tokenstate from `act_dump`.
     pub fn secure_restorable(&self, act_dump: &AccountDump) -> bool {
         self.auth_uri == act_dump.auth_uri
             && self.auth_uri_fields == act_dump.auth_uri_fields

--- a/src/config.rs
+++ b/src/config.rs
@@ -209,7 +209,7 @@ impl Config {
             _ => unreachable!(),
         }
 
-        if let (&Some(None), &Some(None)) = (&http_listen, &https_listen) {
+        if (&http_listen, &https_listen) == (&Some(None), &Some(None)) {
             return Err("Cannot set both http_listen and https_listen to 'none'".into());
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,7 +52,7 @@ impl Config {
     pub fn from_path(conf_path: &Path) -> Result<Self, String> {
         let input = match read_to_string(conf_path) {
             Ok(s) => s,
-            Err(e) => return Err(format!("Can't read {:?}: {}", conf_path, e)),
+            Err(e) => return Err(format!("Can't read {conf_path:?}: {e}")),
         };
         Self::from_str(&input)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,8 +50,7 @@ fn progname() -> String {
     match current_exe() {
         Ok(p) => p
             .file_name()
-            .map(|x| x.to_str().unwrap_or("pizauth"))
-            .unwrap_or("pizauth")
+            .map_or("pizauth", |x| x.to_str().unwrap_or("pizauth"))
             .to_owned(),
         Err(_) => "pizauth".to_owned(),
     }
@@ -341,9 +340,10 @@ fn main() {
                     3 => log::LevelFilter::Debug,
                     _ => log::LevelFilter::Trace,
                 };
-                log::set_boxed_logger(Box::new(syslog::BasicLogger::new(logger)))
-                    .map(|()| log::set_max_level(levelfilter))
-                    .unwrap_or_else(|e| fatal(&format!("Cannot set logger: {e:}")));
+                log::set_boxed_logger(Box::new(syslog::BasicLogger::new(logger))).map_or_else(
+                    |e| fatal(&format!("Cannot set logger: {e:}")),
+                    |()| log::set_max_level(levelfilter),
+                );
                 daemon(true, false).unwrap_or_else(|e| fatal(&format!("Cannot daemonise: {e:}")));
             } else {
                 stderrlog::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,7 +208,7 @@ fn main() {
                 j.as_object_mut()
                     .unwrap()
                     .extend(svj.as_object().unwrap().clone());
-                println!("{}", j);
+                println!("{j}");
             } else {
                 println!("{progname} version {ver}:\n  cache directory: {cache_path}\n  config file: {conf_path}");
                 if let Some(svj) = svj {

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,7 +117,7 @@ fn conf_path(matches: &getopts::Matches) -> PathBuf {
                 None => match env::var_os("HOME") {
                     Some(s) => {
                         p.push(s);
-                        p.push(".config")
+                        p.push(".config");
                     }
                     None => fatal("Neither $XDG_CONFIG_HOME or $HOME set"),
                 },

--- a/src/main.rs
+++ b/src/main.rs
@@ -315,7 +315,7 @@ fn main() {
             //   6 hours of monotonic time
             let sock_path_cl = sock_path.clone();
             thread::spawn(move || loop {
-                thread::sleep(Duration::from_secs(6 * 60 * 60));
+                thread::sleep(Duration::from_hours(6));
                 let _ = utimensat(
                     AT_FDCWD,
                     &sock_path_cl,

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,11 +38,11 @@ use compat::daemon;
 use config::Config;
 use user_sender::show_token;
 
-/// Name of cache directory within $XDG_DATA_HOME.
+/// Name of cache directory within `$XDG_DATA_HOME`.
 const PIZAUTH_CACHE_LEAF: &str = "pizauth";
-/// Name of socket file within $XDG_DATA_HOME/PIZAUTH_CACHE_LEAF.
+/// Name of socket file within `$XDG_DATA_HOME/PIZAUTH_CACHE_LEAF`.
 const PIZAUTH_CACHE_SOCK_LEAF: &str = "pizauth.sock";
-/// Name of `pizauth.conf` file relative to $XDG_CONFIG_HOME.
+/// Name of `pizauth.conf` file relative to `$XDG_CONFIG_HOME`.
 const PIZAUTH_CONF_LEAF: &str = "pizauth.conf";
 
 fn progname() -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod user_sender;
 
 use std::{
     env::{self, current_exe},
+    ffi::OsString,
     fs,
     io::{stdout, Write},
     os::unix::{fs::PermissionsExt, net::UnixStream},
@@ -76,10 +77,7 @@ fn cache_path() -> PathBuf {
     match env::var_os("XDG_RUNTIME_DIR") {
         Some(s) => p.push(s),
         None => {
-            match env::var_os("TMPDIR") {
-                Some(s) => p.push(s),
-                None => p.push("/tmp"),
-            }
+            p.push(env::var_os("TMPDIR").unwrap_or_else(|| OsString::from("/tmp")));
             p.push(format!(
                 "runtime-{}",
                 username().unwrap_or_else(|_| "unknown-user".to_owned())
@@ -126,7 +124,7 @@ fn conf_path(matches: &getopts::Matches) -> PathBuf {
             if !p.is_file() {
                 fatal(&format!(
                     "No config file found at {}",
-                    p.to_str().unwrap_or("pizauth.conf")
+                    p.to_str().unwrap_or(PIZAUTH_CONF_LEAF)
                 ));
             }
             p

--- a/src/server/eventer.rs
+++ b/src/server/eventer.rs
@@ -57,29 +57,22 @@ impl Eventer {
             drop(eventer_lk);
 
             loop {
-                let (act_name, event) =
-                    if let Some((act_name, event)) = self.event_queue.lock().unwrap().pop_front() {
-                        (act_name, event)
-                    } else {
-                        break;
-                    };
-                let token_event_cmd = if let Some(token_event_cmd) =
-                    pstate.ct_lock().config().token_event_cmd.clone()
-                {
-                    token_event_cmd
-                } else {
+                let Some((act_name, event)) = self.event_queue.lock().unwrap().pop_front() else {
                     break;
                 };
-                if let Err(e) = shell_cmd(
+                let Some(token_event_cmd) = pstate.ct_lock().config().token_event_cmd.clone()
+                else {
+                    break;
+                };
+                let _ = shell_cmd(
                     &token_event_cmd,
                     [
                         ("PIZAUTH_ACCOUNT", act_name.as_str()),
                         ("PIZAUTH_EVENT", &event.to_string()),
                     ],
                     TOKEN_EVENT_CMD_TIMEOUT,
-                ) {
-                    error!("{e}");
-                }
+                )
+                .map_err(|e| error!("{e}"));
             }
         });
 

--- a/src/server/eventer.rs
+++ b/src/server/eventer.rs
@@ -24,10 +24,10 @@ pub enum TokenEvent {
 impl Display for TokenEvent {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            TokenEvent::Invalidated => write!(f, "token_invalidated"),
-            TokenEvent::New => write!(f, "token_new"),
-            TokenEvent::Refresh => write!(f, "token_refreshed"),
-            TokenEvent::Revoked => write!(f, "token_revoked"),
+            Self::Invalidated => write!(f, "token_invalidated"),
+            Self::New => write!(f, "token_new"),
+            Self::Refresh => write!(f, "token_refreshed"),
+            Self::Revoked => write!(f, "token_revoked"),
         }
     }
 }
@@ -40,7 +40,7 @@ pub struct Eventer {
 
 impl Eventer {
     pub fn new() -> Result<Self, Box<dyn Error>> {
-        Ok(Eventer {
+        Ok(Self {
             pred: Mutex::new(false),
             condvar: Condvar::new(),
             event_queue: Mutex::new(VecDeque::new()),

--- a/src/server/http_server.rs
+++ b/src/server/http_server.rs
@@ -235,7 +235,7 @@ fn request<T: Read + Write>(
 }
 
 /// If a request to an OAuth server has failed then notify the user of that failure and mark the
-/// tokenstate as [TokenState::Empty] unless the config has changed or the user has initiated a new
+/// tokenstate as [`TokenState::Empty`] unless the config has changed or the user has initiated a new
 /// request while we've been trying (unsuccessfully) with the OAuth server.
 fn fail(
     pstate: Arc<AuthenticatorState>,

--- a/src/server/http_server.rs
+++ b/src/server/http_server.rs
@@ -296,7 +296,7 @@ fn parse_get<T: Read + Write>(stream: &mut T, is_https: bool) -> Result<Url, Box
         }
         http_req_size += line.len();
         match line.chars().next() {
-            Some(' ') | Some('\t') => {
+            Some(' ' | '\t') => {
                 // Continuation of previous header
                 match req.last_mut() {
                     Some(x) => {

--- a/src/server/http_server.rs
+++ b/src/server/http_server.rs
@@ -117,9 +117,7 @@ fn request<T: Read + Write>(
     };
 
     let code_verifier = match ct_lk.tokenstate(act_id) {
-        TokenState::Pending {
-            ref code_verifier, ..
-        } => code_verifier.clone(),
+        TokenState::Pending { code_verifier, .. } => code_verifier.clone(),
         _ => unreachable!(),
     };
     let token_uri = act.token_uri.clone();

--- a/src/server/http_server.rs
+++ b/src/server/http_server.rs
@@ -416,7 +416,9 @@ pub fn https_server_setup(
     match &conf.https_listen {
         Some(https_listen) => {
             // Set a process wide default crypto provider.
-            let _ = rustls::crypto::ring::default_provider().install_default();
+            rustls::crypto::ring::default_provider()
+                .install_default()
+                .map_err(|_| "Failed to install rustls crypto provider")?;
 
             // Generate self-signed certificate
             let mut names = vec![

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -217,7 +217,7 @@ fn request(pstate: Arc<AuthenticatorState>, mut stream: UnixStream) -> Result<()
                             stream.write_all(b"pending:")?;
                         }
                     }
-                    TokenState::Pending { ref url, .. } => {
+                    TokenState::Pending { url, .. } => {
                         let response = if *with_url == "withurl" {
                             format!("pending:{url:}")
                         } else {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -132,7 +132,7 @@ fn request(pstate: Arc<AuthenticatorState>, mut stream: UnixStream) -> Result<()
             match Config::from_path(&pstate.conf_path) {
                 Ok(new_conf) => {
                     pstate.update_conf(new_conf);
-                    stream.write_all(b"ok:")?
+                    stream.write_all(b"ok:")?;
                 }
                 Err(e) => stream.write_all(format!("error:{e:}").as_bytes())?,
             }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -337,10 +337,10 @@ fn startup_cmd(cmd: String) {
                     if !status.success() {
                         error!(
                             "'{cmd:}' returned {}",
-                            status
-                                .code()
-                                .map(|x| x.to_string())
-                                .unwrap_or_else(|| "<Unknown exit code".to_string())
+                            status.code().map_or_else(
+                                || "<Unknown exit code>".to_string(),
+                                |x| x.to_string()
+                            )
                         );
                     }
                 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -38,7 +38,7 @@ use state::{AccountId, AuthenticatorState, CTGuard, TokenState};
 /// Length of the PKCE code verifier in bytes.
 const CODE_VERIFIER_LEN: usize = 64;
 /// The timeout for ureq HTTP requests. It is recommended to make this value lower than
-/// REFRESH_RETRY_DEFAULT to reduce the likelihood that refresh requests overlap.
+/// `REFRESH_RETRY_DEFAULT` to reduce the likelihood that refresh requests overlap.
 pub const UREQ_TIMEOUT: Duration = Duration::from_secs(30);
 /// Length of the OAuth "state" in bytes: this is a string we send when requesting a token that is
 /// echoed back to us, allowing us to distinguish different request. There's no fixed size for
@@ -327,7 +327,7 @@ fn instant_fmt(i: Instant) -> String {
     "<unknown time>".into()
 }
 
-/// If [Config::startup_cmd] is non-`None`, call this function to run that command (in a thread, so
+/// If [`Config::startup_cmd`] is non-`None`, call this function to run that command (in a thread, so
 /// this is non-blocking).
 fn startup_cmd(cmd: String) {
     thread::spawn(move || match env::var("SHELL") {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -94,7 +94,7 @@ fn request(pstate: Arc<AuthenticatorState>, mut stream: UnixStream) -> Result<()
         if len == buf.len() {
             return Err(format!(
                 "Syntactically invalid request '{}'",
-                std::str::from_utf8(&buf).unwrap_or("<can't represent as UTF-8")
+                std::str::from_utf8(&buf).unwrap_or("<can't represent as UTF-8>")
             )
             .into());
         }

--- a/src/server/notifier.rs
+++ b/src/server/notifier.rs
@@ -27,8 +27,8 @@ pub struct Notifier {
 }
 
 impl Notifier {
-    pub fn new() -> Result<Notifier, Box<dyn Error>> {
-        Ok(Notifier {
+    pub fn new() -> Result<Self, Box<dyn Error>> {
+        Ok(Self {
             pred: Mutex::new(false),
             condvar: Condvar::new(),
         })

--- a/src/server/notifier.rs
+++ b/src/server/notifier.rs
@@ -47,7 +47,7 @@ impl Notifier {
                         Some(d) => {
                             #[cfg(debug_assertions)]
                             debug!("Notifier: next wakeup {}", d.as_secs());
-                            notify_lk = self.condvar.wait_timeout(notify_lk, d).unwrap().0
+                            notify_lk = self.condvar.wait_timeout(notify_lk, d).unwrap().0;
                         }
                         None => break,
                     },
@@ -100,7 +100,7 @@ impl Notifier {
                     ],
                     AUTH_NOTIFY_CMD_TIMEOUT,
                 ) {
-                    error!("{e}")
+                    error!("{e}");
                 }
             }
         });
@@ -147,7 +147,7 @@ impl Notifier {
                 ],
                 ERROR_NOTIFY_CMD_TIMEOUT,
             ) {
-                error!("{e}")
+                error!("{e}");
             }
         }
         Ok(())

--- a/src/server/notifier.rs
+++ b/src/server/notifier.rs
@@ -91,7 +91,7 @@ impl Notifier {
             }
             drop(ct_lk);
 
-            for (act_name, cmd, url) in auth_cmds.into_iter() {
+            for (act_name, cmd, url) in auth_cmds {
                 if let Err(e) = shell_cmd(
                     &cmd,
                     [

--- a/src/server/refresher.rs
+++ b/src/server/refresher.rs
@@ -24,7 +24,7 @@ use crate::{
 /// How many times can a transient error be encountered before we try `not_transient_error_if`?
 const TRANSIENT_ERROR_RETRIES: u64 = 6;
 /// How long to run `transient_error_if_cmd` commands before killing them?
-const TRANSIENT_ERROR_IF_CMD_TIMEOUT: Duration = Duration::from_secs(3 * 60);
+const TRANSIENT_ERROR_IF_CMD_TIMEOUT: Duration = Duration::from_mins(3);
 
 /// The outcome of an attempted refresh.
 #[derive(Debug)]

--- a/src/server/refresher.rs
+++ b/src/server/refresher.rs
@@ -48,7 +48,7 @@ pub struct Refresher {
 
 impl Refresher {
     pub fn new() -> Arc<Self> {
-        Arc::new(Refresher {
+        Arc::new(Self {
             pred: Mutex::new(false),
             condvar: Condvar::new(),
         })

--- a/src/server/refresher.rs
+++ b/src/server/refresher.rs
@@ -70,8 +70,8 @@ impl Refresher {
                         let act_id = ct_lk.tokenstate_replace(act_id, new_ts);
                         let act_name = ct_lk.account(act_id).name.clone();
                         match refresher.inner_refresh(&pstate, ct_lk, act_id) {
-                            RefreshKind::AccountOrTokenStateChanged => (),
-                            RefreshKind::NoRefreshToken => (),
+                            RefreshKind::AccountOrTokenStateChanged
+                            | RefreshKind::NoRefreshToken => (),
                             RefreshKind::PermanentError(msg) => {
                                 info!("Permanent refresh error for {act_name}: {msg}");
                                 pstate
@@ -238,10 +238,10 @@ impl Refresher {
                 }
             }
             Err(
-                e @ ureq::Error::ConnectionFailed
-                | e @ ureq::Error::HostNotFound
-                | e @ ureq::Error::Io(_)
-                | e @ ureq::Error::Timeout(_),
+                e @ (ureq::Error::ConnectionFailed
+                | ureq::Error::HostNotFound
+                | ureq::Error::Io(_)
+                | ureq::Error::Timeout(_)),
             ) => return RefreshKind::TransitoryError(act_id, e.to_string()),
             Err(e) => {
                 let mut ct_lk = pstate.ct_lock();

--- a/src/server/refresher.rs
+++ b/src/server/refresher.rs
@@ -415,7 +415,7 @@ impl Refresher {
                         Some(d) => {
                             #[cfg(debug_assertions)]
                             debug!("Refresher: next wakeup {}", d.as_secs());
-                            refresh_lk = refresher.condvar.wait_timeout(refresh_lk, d).unwrap().0
+                            refresh_lk = refresher.condvar.wait_timeout(refresh_lk, d).unwrap().0;
                         }
                         None => break,
                     },

--- a/src/server/refresher.rs
+++ b/src/server/refresher.rs
@@ -443,7 +443,7 @@ impl Refresher {
                 .collect::<HashSet<_>>();
             drop(ct_lk);
 
-            for act_id in to_refresh.iter() {
+            for act_id in &to_refresh {
                 refresher.sched_refresh(Arc::clone(&pstate), *act_id);
             }
         });

--- a/src/server/refresher.rs
+++ b/src/server/refresher.rs
@@ -163,13 +163,13 @@ impl Refresher {
         });
     }
 
-    /// For a [TokenState::Active] token for `act_id`, refresh it, blocking until the token is
-    /// refreshed or an error occurred. This function must be called with a [TokenState::Active]
+    /// For a [`TokenState::Active`] token for `act_id`, refresh it, blocking until the token is
+    /// refreshed or an error occurred. This function must be called with a [`TokenState::Active`]
     /// tokenstate.
     ///
     /// # Panics
     ///
-    /// If the tokenstate is not [TokenState::Active].
+    /// If the tokenstate is not [`TokenState::Active`].
     fn inner_refresh(
         &self,
         pstate: &AuthenticatorState,
@@ -392,8 +392,8 @@ impl Refresher {
             )
     }
 
-    /// Notify the refresher that one or more [TokenState]s is likely to have changed in a way that
-    /// effects the refresher.
+    /// Notify the refresher that one or more [`TokenState`]s is likely to have changed in a way that
+    /// affects the refresher.
     pub fn notify_changes(&self) {
         let mut refresh_lk = self.pred.lock().unwrap();
         *refresh_lk = true;

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -1,15 +1,15 @@
-//! This module contains pizauth's core central state. [AuthenticatorState] is the global state,
-//! but mostly what one is interested in are [Account]s and [TokenState]s. These are (literally)
-//! locked together: every [Account] has a [TokenState] and vice versa. However, a challenge is
+//! This module contains pizauth's core central state. [`AuthenticatorState`] is the global state,
+//! but mostly what one is interested in are [`Account`]s and [`TokenState`]s. These are (literally)
+//! locked together: every [`Account`] has a [`TokenState`] and vice versa. However, a challenge is
 //! that we allow users to reload their config at any point: we have to be very careful about
-//! associating an [Account] with a [TokenState], as we don't want to hand out credentials for an
+//! associating an [`Account`] with a [`TokenState`], as we don't want to hand out credentials for an
 //! old version of an account.
 //!
-//! To that end, we provide an abstraction [AccountId] which is a sort-of "the current version of
-//! an [Account]". Any change to the user's configuration of an [Account] *or* a change to an
-//! [Account]'s associated [TokenState] will cause the [AccountId] to change. Every time a
-//! [CTGuard] is dropped/reacquired, or [tokenstate_replace] is called, [AccountId]s must be
-//! revalidated. Failing to do so will cause panics.
+//! To that end, we provide an abstraction [`AccountId`] which is a sort-of "the current version of
+//! an [`Account`]". Any change to the user's configuration of an [`Account`] *or* a change to an
+//! [`Account`]'s associated [`TokenState`] will cause the [`AccountId`] to change. Every time a
+//! [`CTGuard`] is dropped/reacquired, or [`tokenstate_replace`](CTGuard::tokenstate_replace) is called,
+//! [`AccountId`]s must be revalidated. Failing to do so will cause panics.
 
 use std::{
     collections::HashMap,
@@ -44,8 +44,8 @@ const DUMP_VERSION: u64 = 1;
 /// pizauth's global state.
 pub struct AuthenticatorState {
     pub conf_path: PathBuf,
-    /// The "global lock" protecting the config and current [TokenState]s. Can only be accessed via
-    /// [AuthenticatorState::ct_lock].
+    /// The "global lock" protecting the config and current [`TokenState`]s. Can only be accessed via
+    /// [`AuthenticatorState::ct_lock`].
     locked_state: Mutex<LockedState>,
     /// Port of the HTTP server required by OAuth.
     pub http_port: Option<u16>,
@@ -154,7 +154,7 @@ impl AuthenticatorState {
 struct LockedState {
     config: Config,
     details: Vec<(String, AccountId, TokenState)>,
-    /// The next [AccountId] we'll hand out.
+    /// The next [`AccountId`] we'll hand out.
     ///
     // The account ID may change frequently, and if it wraps, we lose correctness, so we use a
     // ludicrously large type. On my current desktop machine a quick measurement suggests that if
@@ -283,7 +283,7 @@ impl LockedState {
         Ok(())
     }
 
-    /// Returns a unique [AccountId].
+    /// Returns a unique [`AccountId`].
     fn next_account_id(&mut self) -> AccountId {
         let new_id = AccountId {
             id: self.next_account_id,
@@ -299,11 +299,11 @@ struct Dump {
     accounts: HashMap<String, (AccountDump, TokenStateDump)>,
 }
 
-/// A lock guard around the [Config] and tokens. When this guard is dropped:
+/// A lock guard around the [`Config`] and tokens. When this guard is dropped:
 ///
 ///   1. the config lock will be released.
-///   2. any [AccountId] instances created from this [CTGuard] will no longer by valid
-///      i.e. they will not be able to access [Account]s or [TokenState]s until they are
+///   2. any [`AccountId`] instances created from this [`CTGuard`] will no longer by valid
+///      i.e. they will not be able to access [`Account`]s or [`TokenState`]s until they are
 ///      revalidated.
 pub struct CTGuard<'a> {
     guard: MutexGuard<'a, LockedState>,
@@ -318,7 +318,7 @@ impl<'a> CTGuard<'a> {
         &self.guard.config
     }
 
-    /// If `act_name` references a current account, return a [AccountId].
+    /// If `act_name` references a current account, return a [`AccountId`].
     pub fn validate_act_name(&self, act_name: &str) -> Option<AccountId> {
         self.guard
             .details
@@ -327,17 +327,17 @@ impl<'a> CTGuard<'a> {
             .map(|x| x.1)
     }
 
-    /// Is `act_id` still a valid [AccountId]?
+    /// Is `act_id` still a valid [`AccountId`]?
     pub fn is_act_id_valid(&self, act_id: AccountId) -> bool {
         self.guard.details.iter().any(|x| x.1 == act_id)
     }
 
-    /// An iterator that will produce one [AccountId] for each currently active account.
+    /// An iterator that will produce one [`AccountId`] for each currently active account.
     pub fn act_ids(&self) -> impl Iterator<Item = AccountId> + '_ {
         self.guard.details.iter().map(|x| x.1)
     }
 
-    /// Return the [AccountId] with state `state`.
+    /// Return the [`AccountId`] with state `state`.
     pub fn act_id_matching_token_state(&self, state: &str) -> Option<AccountId> {
         self.guard
             .details
@@ -362,8 +362,8 @@ impl<'a> CTGuard<'a> {
         &self.guard.config.accounts[act_name]
     }
 
-    /// Return a reference to the [TokenState] of `act_id`. The user must have validated `act_id`
-    /// under the current [CTGuard].
+    /// Return a reference to the [`TokenState`] of `act_id`. The user must have validated `act_id`
+    /// under the current [`CTGuard`].
     ///
     /// # Panics
     ///
@@ -409,7 +409,7 @@ impl<'a> CTGuard<'a> {
         unreachable!();
     }
 
-    /// Update the tokenstate for `act_id` to `new_tokenstate` returning a new [AccountId]
+    /// Update the tokenstate for `act_id` to `new_tokenstate` returning a new [`AccountId`]
     /// valid for the new tokenstate, updating the tokenstate version.
     ///
     /// # Panics
@@ -433,7 +433,7 @@ impl<'a> CTGuard<'a> {
     }
 }
 
-/// An account ID. Must be created by [LockedState::next_account_id].
+/// An account ID. Must be created by [`LockedState::next_account_id`].
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub struct AccountId {
     id: u128,
@@ -453,7 +453,7 @@ pub enum TokenState {
     /// There is an active token (and, possibly, also an active refresh token).
     Active {
         access_token: String,
-        /// When did we obtain the current access_token?
+        /// When did we obtain the current `access_token`?
         access_token_obtained: Instant,
         /// When does the current access token expire?
         access_token_expiry: Instant,
@@ -472,10 +472,10 @@ pub enum TokenState {
 }
 
 #[derive(Deserialize, Serialize, SchemaRead, SchemaWrite)]
-/// The format of a dumped [TokenState]. Note that [std::time::Instant] instances are translated to
-/// [std::time::SystemTime] instances: there is no guarantee that we can precisely represent the
+/// The format of a dumped [`TokenState`]. Note that [`std::time::Instant`] instances are translated to
+/// [`std::time::SystemTime`] instances: there is no guarantee that we can precisely represent the
 /// latter as the former, so when conversions fail we default to setting values to
-/// [std::time::Instant::now()] or [std::time::SystemTime::now()], as appropriate, as a safe
+/// [`std::time::Instant::now()`] or [`std::time::SystemTime::now()`], as appropriate, as a safe
 /// fallback.
 pub enum TokenStateDump {
     Empty,

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -69,7 +69,7 @@ impl AuthenticatorState {
         notifier: Arc<Notifier>,
         refresher: Arc<Refresher>,
     ) -> Self {
-        AuthenticatorState {
+        Self {
             conf_path,
             locked_state: Mutex::new(LockedState::new(conf)),
             http_port,
@@ -177,7 +177,7 @@ impl LockedState {
             details.push((act_name.to_owned(), act_id, TokenState::Empty));
         }
 
-        LockedState {
+        Self {
             next_account_id,
             config,
             details,
@@ -310,7 +310,7 @@ pub struct CTGuard<'a> {
 }
 
 impl<'a> CTGuard<'a> {
-    fn new(guard: MutexGuard<'a, LockedState>) -> CTGuard<'a> {
+    fn new(guard: MutexGuard<'a, LockedState>) -> Self {
         CTGuard { guard }
     }
 
@@ -504,8 +504,8 @@ impl TokenState {
         }
 
         match self {
-            TokenState::Empty | TokenState::Pending { .. } => TokenStateDump::Empty,
-            TokenState::Active {
+            Self::Empty | Self::Pending { .. } => TokenStateDump::Empty,
+            Self::Active {
                 access_token,
                 access_token_obtained,
                 access_token_expiry,
@@ -522,7 +522,7 @@ impl TokenState {
         }
     }
 
-    pub fn restore(tsd: &TokenStateDump) -> TokenState {
+    pub fn restore(tsd: &TokenStateDump) -> Self {
         fn restore_instant(t: &SystemTime) -> Instant {
             let i;
             if let Ok(d) = t.duration_since(SystemTime::now()) {
@@ -538,13 +538,13 @@ impl TokenState {
         }
 
         match tsd {
-            TokenStateDump::Empty => TokenState::Empty,
+            TokenStateDump::Empty => Self::Empty,
             TokenStateDump::Active {
                 access_token,
                 access_token_obtained,
                 access_token_expiry,
                 refresh_token,
-            } => TokenState::Active {
+            } => Self::Active {
                 access_token: access_token.clone(),
                 access_token_obtained: restore_instant(access_token_obtained),
                 access_token_expiry: restore_instant(access_token_expiry),

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -178,9 +178,9 @@ impl LockedState {
         }
 
         Self {
-            next_account_id,
             config,
             details,
+            next_account_id,
         }
     }
 

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -257,14 +257,14 @@ impl LockedState {
                         (
                             &TokenState::Empty | &TokenState::Pending { .. },
                             &TokenState::Empty | &TokenState::Pending { .. },
-                        ) => (),
+                        )
+                        | (&TokenState::Active { .. }, _) => (),
                         (
                             &TokenState::Empty | &TokenState::Pending { .. },
                             &TokenState::Active { .. },
                         ) => {
                             restore.insert(act_name.to_owned(), new_ts);
                         }
-                        (&TokenState::Active { .. }, _) => (),
                     }
                 }
             }
@@ -504,8 +504,7 @@ impl TokenState {
         }
 
         match self {
-            TokenState::Empty => TokenStateDump::Empty,
-            TokenState::Pending { .. } => TokenStateDump::Empty,
+            TokenState::Empty | TokenState::Pending { .. } => TokenStateDump::Empty,
             TokenState::Active {
                 access_token,
                 access_token_obtained,

--- a/src/shell_cmd.rs
+++ b/src/shell_cmd.rs
@@ -24,8 +24,7 @@ pub fn shell_cmd<const T: usize>(
             "'{cmd:}' returned {}",
             status
                 .code()
-                .map(|x| x.to_string())
-                .unwrap_or_else(|| "<Unknown exit code".to_string())
+                .map_or_else(|| "<Unknown exit code".to_string(), |x| x.to_string())
         )
         .into()),
         None => {

--- a/src/shell_cmd.rs
+++ b/src/shell_cmd.rs
@@ -24,7 +24,7 @@ pub fn shell_cmd<const T: usize>(
             "'{cmd:}' returned {}",
             status
                 .code()
-                .map_or_else(|| "<Unknown exit code".to_string(), |x| x.to_string())
+                .map_or_else(|| "<Unknown exit code>".to_string(), |x| x.to_string())
         )
         .into()),
         None => {

--- a/src/user_sender.rs
+++ b/src/user_sender.rs
@@ -13,7 +13,7 @@ pub fn dump(cache_path: &Path) -> Result<Vec<u8>, Box<dyn Error>> {
     let mut stream = UnixStream::connect(sock_path)
         .map_err(|_| "pizauth authenticator not running or not responding")?;
     stream
-        .write_all("dump:".as_bytes())
+        .write_all(b"dump:")
         .map_err(|_| "Socket not writeable")?;
     stream.shutdown(Shutdown::Write)?;
 
@@ -27,7 +27,7 @@ pub fn server_info(cache_path: &Path) -> Result<serde_json::Value, Box<dyn Error
     let mut stream = UnixStream::connect(sock_path)
         .map_err(|_| "pizauth authenticator not running or not responding")?;
     stream
-        .write_all("info:".as_bytes())
+        .write_all(b"info:")
         .map_err(|_| "Socket not writeable")?;
     stream.shutdown(Shutdown::Write)?;
 
@@ -83,7 +83,7 @@ pub fn restore(cache_path: &Path) -> Result<(), Box<dyn Error>> {
     let mut stream = UnixStream::connect(sock_path)
         .map_err(|_| "pizauth authenticator not running or not responding")?;
     stream
-        .write_all("restore:".as_bytes())
+        .write_all(b"restore:")
         .map_err(|_| "Socket not writeable")?;
     stream.write_all(&buf).map_err(|_| "Socket not writeable")?;
     stream.shutdown(Shutdown::Write)?;
@@ -155,7 +155,7 @@ pub fn status(cache_path: &Path) -> Result<(), Box<dyn Error>> {
     let mut stream = UnixStream::connect(sock_path)
         .map_err(|_| "pizauth authenticator not running or not responding")?;
     stream
-        .write_all("status:".as_bytes())
+        .write_all(b"status:")
         .map_err(|_| "Socket not writeable")?;
     stream.shutdown(Shutdown::Write)?;
 


### PR DESCRIPTION
Enables all lints, paring them back so the codebase still reports as clean.
Then, one by one turns lints back on and handles them
Lints were not enabled in any particular order, but tried to keep to one lint per commit.
Lints excised through this PR:
```
[rustc] if_let_rescope
[rustc] let_underscore_drop
[rustc] rust_2024_incompatible_pat
[clippy] doc_markdown
[clippy] duration_suboptimal_units
[clippy] equatable_if_let
[clippy] explicit_into_iter_loop
[clippy] explicit_iter_loop
[clippy] inconsistent_struct_constructor
[clippy] manual_let_else
[clippy] map_unwrap_or
[clippy] match_same_arms
[clippy] path_buf_push_overwrite
[clippy] semicolon_if_nothing_returned
[clippy] string_lit_as_bytes
[clippy] uninlined_format_args
[clippy] unnested_or_patterns
[clippy] use_self
```

Final commit classifies the remaining lints for future work. In particular, those marked under "Heavy changes" flag those pattern matches I originally flagged, but as I was getting into their weeds I realized the changes were getting too big for one PR.
