### PR TITLE
Straightforward Clippy linting suggestions (part 2: test code)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,15 +74,22 @@ rust_2024_compatibility = "deny"
 let_underscore = "warn"
 
 ## TODO, disabled since they currently fail
+let_underscore_drop = { level = "allow", priority = 1 }
 ### Would change style
 elided_lifetimes_in_paths = { level = "allow", priority = 1 }
 ### Needs analysis + oversight for correctness
 tail_expr_drop_order = { level = "allow", priority = 1 }
 
 [lints.clippy]
+## TODO, disabled since they currently fail
+### Straightforward fix, for next PR
+no_effect = { level = "allow", priority = 1 }
+
 pedantic = "warn"
 ## TODO, disabled since they currently fail
 ### Straightforward fix, for next PR
+manual_string_new = { level = "allow", priority = 1 }
+items_after_statements = { level = "allow", priority = 1 }
 ignored_unit_patterns = { level = "allow", priority = 1 }
 implicit_clone = { level = "allow", priority = 1 }
 unused_self = { level = "allow", priority = 1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,6 @@ rust_2024_compatibility = "deny"
 let_underscore = "warn"
 
 ## TODO, disabled since they currently fail
-let_underscore_drop = { level = "allow", priority = 1 }
 ### Would change style
 elided_lifetimes_in_paths = { level = "allow", priority = 1 }
 ### Needs analysis + oversight for correctness

--- a/src/config.rs
+++ b/src/config.rs
@@ -936,7 +936,7 @@ mod test {
                     "Account x has an 'http' redirect but the HTTP server is set to 'none'",
                 ) =>
             {
-                ()
+                ();
             }
             Err(e) => panic!("{e:?}"),
             _ => panic!(),
@@ -957,7 +957,7 @@ mod test {
                     "Account x has an 'https' redirect but the HTTPS server is set to 'none'",
                 ) =>
             {
-                ()
+                ();
             }
             Err(e) => panic!("{e:?}"),
             _ => panic!(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -704,18 +704,12 @@ mod test {
     fn test_time_str_to_duration() {
         assert_eq!(time_str_to_duration("0s").unwrap(), Duration::from_secs(0));
         assert_eq!(time_str_to_duration("1s").unwrap(), Duration::from_secs(1));
-        assert_eq!(time_str_to_duration("1m").unwrap(), Duration::from_secs(60));
-        assert_eq!(
-            time_str_to_duration("2m").unwrap(),
-            Duration::from_secs(120)
-        );
-        assert_eq!(
-            time_str_to_duration("1h").unwrap(),
-            Duration::from_secs(3600)
-        );
+        assert_eq!(time_str_to_duration("1m").unwrap(), Duration::from_mins(1));
+        assert_eq!(time_str_to_duration("2m").unwrap(), Duration::from_mins(2));
+        assert_eq!(time_str_to_duration("1h").unwrap(), Duration::from_hours(1));
         assert_eq!(
             time_str_to_duration("1d").unwrap(),
-            Duration::from_secs(86400)
+            Duration::from_hours(24)
         );
 
         assert!(time_str_to_duration("9223372036854775808m").is_err());
@@ -762,7 +756,7 @@ mod test {
         .unwrap();
         assert_eq!(c.error_notify_cmd, Some("j".to_owned()));
         assert_eq!(c.auth_notify_cmd, Some("g".to_owned()));
-        assert_eq!(c.auth_notify_interval, Duration::from_secs(88 * 60));
+        assert_eq!(c.auth_notify_interval, Duration::from_mins(88));
         assert_eq!(c.http_listen, Some("127.0.0.1:56789".to_owned()));
         assert_eq!(c.transient_error_if_cmd, Some("k".to_owned()));
         assert_eq!(c.token_event_cmd, Some("q".to_owned()));
@@ -782,7 +776,7 @@ mod test {
         assert_eq!(act.redirect_uri, "http://e.com");
         assert_eq!(act.token_uri, "http://f.com");
         assert_eq!(&act.scopes, &["c".to_owned(), "d".to_owned()]);
-        assert_eq!(act.refresh_at_least, Some(Duration::from_secs(43 * 60)));
+        assert_eq!(act.refresh_at_least, Some(Duration::from_mins(43)));
         assert_eq!(act.refresh_before_expiry, Some(Duration::from_secs(42)));
         assert_eq!(act.refresh_retry(&c), Duration::from_secs(33));
     }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -801,7 +801,7 @@ mod test {
                     access_token: "abc".to_owned(),
                     access_token_obtained: Instant::now(),
                     access_token_expiry: Instant::now()
-                        .checked_add(Duration::from_secs(60))
+                        .checked_add(Duration::from_mins(1))
                         .unwrap(),
                     refresh_token: None,
                     ongoing_refresh: false,
@@ -892,7 +892,7 @@ mod test {
                     access_token: "abc".to_owned(),
                     access_token_obtained: Instant::now(),
                     access_token_expiry: Instant::now()
-                        .checked_add(Duration::from_secs(60))
+                        .checked_add(Duration::from_mins(1))
                         .unwrap(),
                     refresh_token: Some("refresh".to_owned()),
                     ongoing_refresh: false,

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -52,7 +52,7 @@ impl Drop for PizauthServer {
         assert!(cmd.unwrap().status.success());
         // Currently we kill the main server with SIGTERM, so this `wait` would return an error if
         // we checked!
-        let _ = self.child.wait();
+        drop(self.child.wait());
     }
 }
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -240,8 +240,7 @@ impl HttpRequest {
 
         let content_length = headers
             .get("content-length")
-            .map(|x| x.parse::<usize>().unwrap())
-            .unwrap_or(0);
+            .map_or(0, |x| x.parse::<usize>().unwrap());
         let mut body = vec![0; content_length];
         reader.read_exact(&mut body).unwrap();
         let stream = reader.into_inner();

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -39,7 +39,7 @@ impl PizauthServer {
             thread::sleep(Duration::from_millis(25));
         }
         assert!(readyp.exists());
-        PizauthServer {
+        Self {
             child,
             xdg_dir: xdg_dir.to_owned(),
         }
@@ -77,7 +77,7 @@ impl OAuthServer {
             })
         };
 
-        OAuthServer {
+        Self {
             addr,
             thread: Some(thread),
         }
@@ -246,7 +246,7 @@ impl HttpRequest {
         reader.read_exact(&mut body).unwrap();
         let stream = reader.into_inner();
 
-        HttpRequest {
+        Self {
             stream,
             method,
             target,


### PR DESCRIPTION
It turns out that without `--all-targets --all-features`, Clippy doesn't exercise test codepaths. It also doesn't exercise non-build system platforms, so unless and until I figure out cross-compilation, the only way of checking the `macos` and `openbsd`-specific code would be to run Clippy in CI on a test runner for those. And we're not testing `openbsd` at all, as pointed out in #85...
These commits should make `cargo clippy --all-targets --all-features` come out cleanly on all platforms. It may be useful to add that step to CI to avoid regressions, like we do for `cargo fmt`.
