### PR TITLE
CI: test on OpenBSD

### DIFF
--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -1,0 +1,22 @@
+name: CI OpenBSD
+
+on:
+  pull_request:
+
+jobs:
+  openbsd:
+    runs-on: ubuntu-latest
+    name: Tests OpenBSD x86_64
+    steps:
+    - uses: actions/checkout@v7
+    - name: Build and test in an OpenBSD VM
+      uses: vmactions/openbsd-vm@v1
+      with:
+        usesh: true
+        cache-after-prepare: true
+        prepare: |
+          pkg_add rust
+        run: |
+          set -e
+          cargo test
+          cargo test --release


### PR DESCRIPTION
Closes #85.

pizauth has OpenBSD-specific `pledge`/`unveil` code, but CI only ran on Linux and macOS, so that path was never exercised. This runs the test suite in an OpenBSD VM using `vmactions/openbsd-vm` -- one of the two options suggested in the issue.

**Notes**

- **A separate workflow file rather than a job in `ci.yml`** -- leaves the existing matrix untouched, and triggers on `pull_request` exactly as `ci.yml` does.

- **Rust comes from `pkg_add rust`** (OpenBSD's packaged toolchain, currently 1.97.1) rather than rustup, which has no OpenBSD host builds.

- `cache-after-prepare: true` caches the VM image once the toolchain is installed, so later runs restore it and skip the install.

**Verification**

Green on my fork at this commit: https://github.com/neilpang/pizauth/actions/runs/30342063544

The log shows the OpenBSD-only dependencies genuinely building -- `Compiling unveil v0.3.2`, `Compiling pledge v0.4.2` -- and both `cargo test` and `cargo test --release` passing (21 + 2 tests each, 0 failed). The integration suite starts the real daemon and asserts that it became ready, so the `pledge`/`unveil` startup path in `src/server/mod.rs` is now actually exercised rather than merely compiled.
