### PR TITLE
Enable platform verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -177,6 +177,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,10 +269,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -846,6 +872,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,6 +1160,12 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "packedvec"
@@ -1368,6 +1444,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1375,6 +1463,33 @@ checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -1403,11 +1518,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "sd-notify"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e4ef7359e694bfaf1dd27a30f9d760b54c00dfae9f19bd0c05a39bc9128fe76"
 dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
  "libc",
 ]
 
@@ -1596,11 +1743,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1739,6 +1906,7 @@ dependencies = [
  "percent-encoding",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "ureq-proto",
  "utf8-zero",
  "webpki-roots",
@@ -1974,6 +2142,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2013,7 +2190,7 @@ dependencies = [
  "pastey",
  "proc-macro2",
  "quote",
- "thiserror",
+ "thiserror 2.0.18",
  "wincode-derive",
 ]
 
@@ -2090,11 +2267,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2108,19 +2294,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2130,9 +2337,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2148,9 +2367,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2160,9 +2391,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2284,7 +2527,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ sha2 = "0.11.0"
 serde_json = "1"
 stderrlog = "0.6"
 syslog = "7.0.0"
-ureq = "3"
+ureq = { version = "3", features = ["platform-verifier"] }
 url = "2"
 wait-timeout = "0.2"
 whoami = "2.1.2"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,24 @@ notifications of authorisation requests and errors, which requires setting
 See [the bundled example configuration](examples/pizauth.conf) for more details.
 
 
+### TLS trust
+
+For outbound HTTPS requests, pizauth uses ureq's Rustls platform certificate
+verifier. Certificate and hostname verification remain enabled.
+
+On macOS, trust follows the Security framework and its user, administrator, and
+system-managed trust settings. On Linux and BSD, trust follows native CA
+discovery. For those Unix-like systems, `SSL_CERT_FILE` may name a PEM CA bundle
+and `SSL_CERT_DIR` may name an OpenSSL `c_rehash`-style CA directory; when set,
+these variables control the native CA source for the pizauth process instead of
+the discovered system source.
+
+Pizauth does not currently provide a separate CA-bundle configuration and does
+not disable certificate validation or fall back to Mozilla roots. Windows is not
+currently a supported pizauth target; if Windows support is added in the future,
+ureq's platform verifier will use the Windows certificate store.
+
+
 ### Account setup
 
 At a minimum you need to find out from your provider:

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,22 +306,6 @@ fn main() {
                 fs::remove_file(&sock_path).ok();
             }
 
-            // The XDG spec says of `$XDG_RUNTIME_DIR` (where our socket file will live):
-            //   Files in this directory MAY be subjected to periodic clean-up. To ensure that your files
-            //   are not removed, they should have their access time timestamp modified at least once every
-            //   6 hours of monotonic time
-            let sock_path_cl = sock_path;
-            thread::spawn(move || loop {
-                thread::sleep(Duration::from_hours(6));
-                let _ = utimensat(
-                    AT_FDCWD,
-                    &sock_path_cl,
-                    &TimeSpec::UTIME_NOW,
-                    &TimeSpec::UTIME_NOW,
-                    UtimensatFlags::NoFollowSymlink,
-                );
-            });
-
             let conf_path = conf_path(&matches);
             let conf = Config::from_path(&conf_path).unwrap_or_else(|m| fatal(&m));
 
@@ -352,6 +336,26 @@ fn main() {
                     .init()
                     .unwrap();
             }
+
+            // Start threads only after daemonisation. On macOS, platform TLS verification uses
+            // Security.framework, which cannot safely be initialized in a forked child of a
+            // multithreaded process.
+            // The XDG spec says of `$XDG_RUNTIME_DIR` (where our socket file will live):
+            //   Files in this directory MAY be subjected to periodic clean-up. To ensure that your files
+            //   are not removed, they should have their access time timestamp modified at least once every
+            //   6 hours of monotonic time
+            let sock_path_cl = sock_path;
+            thread::spawn(move || loop {
+                thread::sleep(Duration::from_hours(6));
+                let _ = utimensat(
+                    AT_FDCWD,
+                    &sock_path_cl,
+                    &TimeSpec::UTIME_NOW,
+                    &TimeSpec::UTIME_NOW,
+                    UtimensatFlags::NoFollowSymlink,
+                );
+            });
+
             if let Err(e) = server::server(conf_path, conf, cache_path.as_path()) {
                 error!("{e:}");
                 process::exit(1);

--- a/src/server/http_server.rs
+++ b/src/server/http_server.rs
@@ -20,7 +20,6 @@ use rustls::{
 
 use super::{
     eventer::TokenEvent, expiry_instant, AccountId, AuthenticatorState, Config, TokenState,
-    UREQ_TIMEOUT,
 };
 
 /// How often should we try making a request to an OAuth server for possibly-temporary transport
@@ -150,9 +149,7 @@ fn request<T: Read + Write>(
     // request that partially makes a connection but does not then fully succeed is an error (since
     // we can't reuse authentication codes), and we'll have to start again entirely.
     let mut body = None;
-    let agent_conf = ureq::Agent::config_builder()
-        .timeout_global(Some(UREQ_TIMEOUT))
-        .build();
+    let agent_conf = super::ureq_config();
     for _ in 0..RETRY_POST {
         match ureq::Agent::new_with_config(agent_conf.clone())
             .post(token_uri.as_str())

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -5,6 +5,10 @@ mod refresher;
 mod request_token;
 mod state;
 
+#[cfg(any(test, target_os = "openbsd"))]
+use std::ffi::OsString;
+#[cfg(target_os = "openbsd")]
+use std::os::unix::ffi::OsStrExt;
 use std::{
     collections::HashMap,
     env,
@@ -52,6 +56,30 @@ fn ureq_config() -> ureq::config::Config {
                 .build(),
         )
         .build()
+}
+
+#[cfg(any(test, target_os = "openbsd"))]
+fn ssl_cert_paths(cert_file: Option<OsString>, cert_dirs: Option<OsString>) -> Vec<PathBuf> {
+    let mut paths = vec![PathBuf::from("/etc/ssl/cert.pem")];
+    if let Some(cert_file) = cert_file {
+        paths.push(cert_file.into());
+    }
+    if let Some(cert_dirs) = cert_dirs {
+        paths.extend(env::split_paths(&cert_dirs).filter(|path| !path.as_os_str().is_empty()));
+    }
+    paths
+}
+
+#[cfg(target_os = "openbsd")]
+fn unveil_ssl_cert_paths() -> Result<(), Box<dyn Error>> {
+    let paths = ssl_cert_paths(env::var_os("SSL_CERT_FILE"), env::var_os("SSL_CERT_DIR"))
+        .into_iter()
+        .filter(|path| path.exists())
+        .collect::<Vec<_>>();
+    for path in paths {
+        unveil(path.as_os_str().as_bytes(), "r")?;
+    }
+    Ok(())
 }
 /// Length of the OAuth "state" in bytes: this is a string we send when requesting a token that is
 /// echoed back to us, allowing us to distinguish different request. There's no fixed size for
@@ -373,6 +401,8 @@ pub fn server(conf_path: PathBuf, conf: Config, cache_path: &Path) -> Result<(),
     let sock_path = sock_path(cache_path);
 
     #[cfg(target_os = "openbsd")]
+    unveil_ssl_cert_paths()?;
+    #[cfg(target_os = "openbsd")]
     unveil(
         conf_path
             .as_os_str()
@@ -475,5 +505,21 @@ mod tests {
             ureq::tls::RootCerts::PlatformVerifier
         ));
         assert!(!config.tls_config().disable_verification());
+    }
+
+    #[test]
+    fn ssl_cert_paths_include_default_and_environment_paths() {
+        assert_eq!(
+            ssl_cert_paths(
+                Some("/custom/ca.pem".into()),
+                Some("/custom/certs:/another/certs".into()),
+            ),
+            vec![
+                PathBuf::from("/etc/ssl/cert.pem"),
+                PathBuf::from("/custom/ca.pem"),
+                PathBuf::from("/custom/certs"),
+                PathBuf::from("/another/certs"),
+            ]
+        );
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -42,6 +42,17 @@ const CODE_VERIFIER_LEN: usize = 64;
 /// The timeout for ureq HTTP requests. It is recommended to make this value lower than
 /// `REFRESH_RETRY_DEFAULT` to reduce the likelihood that refresh requests overlap.
 pub const UREQ_TIMEOUT: Duration = Duration::from_secs(30);
+
+fn ureq_config() -> ureq::config::Config {
+    ureq::Agent::config_builder()
+        .timeout_global(Some(UREQ_TIMEOUT))
+        .tls_config(
+            ureq::tls::TlsConfig::builder()
+                .root_certs(ureq::tls::RootCerts::PlatformVerifier)
+                .build(),
+        )
+        .build()
+}
 /// Length of the OAuth "state" in bytes: this is a string we send when requesting a token that is
 /// echoed back to us, allowing us to distinguish different request. There's no fixed size for
 /// this, and indeed one can go perhaps up to at least a kilobyte, but that's probably not going to
@@ -450,4 +461,19 @@ pub fn server(conf_path: PathBuf, conf: Config, cache_path: &Path) -> Result<(),
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ureq_config_uses_platform_verifier() {
+        let config = ureq_config();
+        assert!(matches!(
+            config.tls_config().root_certs(),
+            ureq::tls::RootCerts::PlatformVerifier
+        ));
+        assert!(!config.tls_config().disable_verification());
+    }
 }

--- a/src/server/refresher.rs
+++ b/src/server/refresher.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 use crate::{
     server::{
         eventer::TokenEvent, expiry_instant, AccountId, AuthenticatorState, CTGuard, TokenState,
-        MAX_WAIT_SECS, UREQ_TIMEOUT,
+        MAX_WAIT_SECS,
     },
     shell_cmd::shell_cmd,
 };
@@ -212,9 +212,7 @@ impl Refresher {
         }
 
         drop(ct_lk);
-        let agent_conf = ureq::Agent::config_builder()
-            .timeout_global(Some(UREQ_TIMEOUT))
-            .build();
+        let agent_conf = super::ureq_config();
         let body = match ureq::Agent::new_with_config(agent_conf)
             .post(token_uri.as_str())
             .send_form(pairs)


### PR DESCRIPTION
Closes #100.

- Adds `ureq` `platform-verifier` dependency.
- Adds a config helper function b/c `http_server.rs` and `refresher.rs` use the same code
- Reorders thread & fork calls b/c thread-before-fork causes an Objective-C fork-safety exception. `rustls-platform-verifier` calls into macOS `Security.framework` (obj-c). The reordering appears safe, and the alternative was a more extensive refactoring.